### PR TITLE
NEW: Annotation schema

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,9 @@ https://github.com/digitallinguistics/spec/blob/master/.github/CONTRIBUTING.md#c
 
 -->
 
-## Checklist (see [Contributing Guidelines](https://github.com/digitallinguistics/spec/blob/master/.github/CONTRIBUTING.md#contributing-code--changes-to-the-schemas))
+## Checklist
+
+[Contributing Guidelines](https://github.com/digitallinguistics/spec/blob/master/.github/CONTRIBUTING.md#contributing-code--changes-to-the-schemas)
 
 - [ ] **[Open an issue](https://github.com/digitallinguistics/spec/issues/new)** if you haven't already
 - [ ] **Fork the repository** and clone it to your computer

--- a/schemas/json/Annotation.json
+++ b/schemas/json/Annotation.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "http://cdn.digitallinguistics.io/schemas/Annotation-1.0.0.json",
+  "title": "Annotation",
+  "type": "object",
+  "description": "An annotation on a text. Annotations are useful for indicating properties of a text which are anchored in time, or which cross the boundaries of linguistic objects like utterances and words. Examples uses might include: annotating a period of time when a speaker is whispering; annotating a stretch of the text as being a particular episode in the text; annotating the text for turns or prosodic units. Annotations should generally be used as a last resort. Whenever possible, data should be attached to linguistic objects, and represented as attributes of those linguistic entities. For example, it would be bad practice to use a timespan annotation to indicate the start and end times of a word. Instead, you should add the custom properties `startTime` and `endTime` to each Word object. Each annotation must have either a `notes` or a `tags` property specified, in order to describe the annotation.",
+  "required": [
+    "annotationType"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "annotationType": {
+      "title": "Annotation Type",
+      "type": "string",
+      "description": "The type of Annotation",
+      "enum": [
+        "timespan",
+        "timestamp"
+      ]
+    },
+    "notes": {
+      "title": "Notes",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "description": "A collection of notes for this Annotation",
+      "items": {
+        "title": "Note",
+        "type": "object",
+        "$ref": "http://cdn.digitallinguistics.io/schemas/Note.json",
+        "description": "A Note about this Annotation"
+      }
+    },
+    "tags": {
+      "title": "Tags",
+      "type": "object",
+      "$ref": "http://cdn.digitallinguistics.io/schemas/Tags.json",
+      "description": "A set of tags for this Annotation"
+    }
+  },
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "required": [
+            "notes"
+          ]
+        },
+        {
+          "required": [
+            "tags"
+          ]
+        }
+      ]
+    },
+    {
+      "oneOf": [
+        {
+          "title": "Timespan Annotation",
+          "description": "A timespan annotation is an annotation which spans a duration of time. This is particularly useful for annotating non-linguistic features of the text which are happening in the background.",
+          "required": [
+            "ts"
+          ],
+          "properties": {
+            "ts": {
+              "title": "Timestamp",
+              "type": "number",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "description": "The point in time that the annotation is about, formated in seconds and millseconds (SS.MMM)"
+            }
+          }
+        },
+        {
+          "title": "Timestamp Annotation",
+          "description": "A timestamp annotation is an annotation at a single point in time in a text. It should be used for data that do not have a duration, or to attach generic notes with observations at specific points in time.",
+          "required": [
+            "startTime",
+            "endTime"
+          ],
+          "properties": {
+            "startTime": {
+              "title": "Start Time",
+              "type": "number",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "description": "The time that the annotation starts, formated in seconds and milliseconds (SS.MMM)"
+            },
+            "endTime": {
+              "title": "End Time",
+              "type": "number",
+              "minimum": 0.001,
+              "exclusiveMinimum": true,
+              "description": "The time that the annotation ends, formatted in seconds and milliseconds (SS.MMM)"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/json/Text.json
+++ b/schemas/json/Text.json
@@ -30,6 +30,19 @@
       "$ref": "http://cdn.digitallinguistics.io/schemas/Access.json",
       "description": "An object describing the acess rights to this Text"
     },
+    "annotations": {
+      "title": "Annotations",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "description": "A collection of annotations on this text",
+      "items": {
+        "title": "Annotation",
+        "type": "object",
+        "$ref": "http://cdn.digitallinguistics.io/schemas/Annotation.json",
+        "description": "An annotation on this text"
+      }
+    },
     "contributors": {
       "title": "Contributors",
       "type": "array",

--- a/schemas/json/index.js
+++ b/schemas/json/index.js
@@ -2,6 +2,7 @@ module.exports = {
   Abbreviation: require('./Abbreviation'),
   Access: require('./Access'),
   Address: require('./Address'),
+  Annotation: require('./Annotation'),
   Bundle: require('./Bundle'),
   DateCreated: require('./DateCreated'),
   DateModified: require('./DateModified'),

--- a/schemas/yaml/Annotation.yml
+++ b/schemas/yaml/Annotation.yml
@@ -1,5 +1,5 @@
 $schema: 'http://json-schema.org/schema#'
-id:      'http://cdn.digitallinguistics.io/schemas/Annotation-1.1.0.json'
+id:      'http://cdn.digitallinguistics.io/schemas/Annotation-1.0.0.json'
 title:   Annotation
 type:    object
 
@@ -40,9 +40,11 @@ properties:
 
 allOf:
 
-  - oneOf:
-    - required: notes
-    - required: tags
+  - anyOf:
+    - required:
+        - notes
+    - required:
+        - tags
 
   - oneOf:
 
@@ -55,7 +57,8 @@ allOf:
         ts:
           title:            Timestamp
           type:             number
-          exclusiveMinimum: 0
+          minimum:          0
+          exclusiveMinimum: true
           description: 'The point in time that the annotation is about, formated in seconds and millseconds (SS.MMM)'
 
     - title: 'Timestamp Annotation'
@@ -68,11 +71,13 @@ allOf:
         startTime:
           title:            'Start Time'
           type:             number
-          exclusiveMinimum: 0
+          minimum:          0
+          exclusiveMinimum: true
           description: 'The time that the annotation starts, formated in seconds and milliseconds (SS.MMM)'
 
         endTime:
           title:            'End Time'
           type:             number
-          exclusiveMinimum: 0.001
+          minimum:          0.001
+          exclusiveMinimum: true
           description: 'The time that the annotation ends, formatted in seconds and milliseconds (SS.MMM)'

--- a/schemas/yaml/Annotation.yml
+++ b/schemas/yaml/Annotation.yml
@@ -1,0 +1,78 @@
+$schema: 'http://json-schema.org/schema#'
+id:      'http://cdn.digitallinguistics.io/schemas/Annotation-1.1.0.json'
+title:   Annotation
+type:    object
+
+description: 'An annotation on a text. Annotations are useful for indicating properties of a text which are anchored in time, or which cross the boundaries of linguistic objects like utterances and words. Examples uses might include: annotating a period of time when a speaker is whispering; annotating a stretch of the text as being a particular episode in the text; annotating the text for turns or prosodic units. Annotations should generally be used as a last resort. Whenever possible, data should be attached to linguistic objects, and represented as attributes of those linguistic entities. For example, it would be bad practice to use a timespan annotation to indicate the start and end times of a word. Instead, you should add the custom properties `startTime` and `endTime` to each Word object. Each annotation must have either a `notes` or a `tags` property specified, in order to describe the annotation.'
+
+required:
+  - annotationType
+
+additionalProperties: true
+
+properties:
+
+  annotationType:
+    title: 'Annotation Type'
+    type:  string
+    description: 'The type of Annotation'
+    enum:
+      - timespan
+      - timestamp
+
+  notes:
+    title:       Notes
+    type:        array
+    uniqueItems: true
+    minItems:    1
+    description: A collection of notes for this Annotation
+    items:
+      title: Note
+      type:  object
+      $ref:  'http://cdn.digitallinguistics.io/schemas/Note.json'
+      description: 'A Note about this Annotation'
+
+  tags:
+    title: Tags
+    type:  object
+    $ref:  'http://cdn.digitallinguistics.io/schemas/Tags.json'
+    description: 'A set of tags for this Annotation'
+
+allOf:
+
+  - oneOf:
+    - required: notes
+    - required: tags
+
+  - oneOf:
+
+    - title: 'Timespan Annotation'
+      description: 'A timespan annotation is an annotation which spans a duration of time. This is particularly useful for annotating non-linguistic features of the text which are happening in the background.'
+      required:
+        - ts
+      properties:
+
+        ts:
+          title:            Timestamp
+          type:             number
+          exclusiveMinimum: 0
+          description: 'The point in time that the annotation is about, formated in seconds and millseconds (SS.MMM)'
+
+    - title: 'Timestamp Annotation'
+      description: 'A timestamp annotation is an annotation at a single point in time in a text. It should be used for data that do not have a duration, or to attach generic notes with observations at specific points in time.'
+      required:
+        - startTime
+        - endTime
+      properties:
+
+        startTime:
+          title:            'Start Time'
+          type:             number
+          exclusiveMinimum: 0
+          description: 'The time that the annotation starts, formated in seconds and milliseconds (SS.MMM)'
+
+        endTime:
+          title:            'End Time'
+          type:             number
+          exclusiveMinimum: 0.001
+          description: 'The time that the annotation ends, formatted in seconds and milliseconds (SS.MMM)'

--- a/schemas/yaml/Text.yml
+++ b/schemas/yaml/Text.yml
@@ -32,6 +32,18 @@ properties:
     $ref: 'http://cdn.digitallinguistics.io/schemas/Access.json'
     description: 'An object describing the acess rights to this Text'
 
+  annotations:
+    title:       'Annotations'
+    type:        array
+    uniqueItems: true
+    minItems:    1
+    description: 'A collection of annotations on this text'
+    items:
+      title: Annotation
+      type:  object
+      $ref:  'http://cdn.digitallinguistics.io/schemas/Annotation.json'
+      description: 'An annotation on this text'
+
   contributors:
     title: Contributors
     type:  array

--- a/test/Annotation.test.js
+++ b/test/Annotation.test.js
@@ -1,0 +1,55 @@
+// IMPORTS
+const { AJV } = require(`./utilities`);
+
+// VARIABLES
+let ajv;
+let validate;
+
+// VALID SAMPLE DATA
+const timestampData = {
+  annotationType: `timestamp`,
+  notes:          [
+    {
+      text: `Points to door.`,
+    },
+  ],
+  tags:           {
+    gestureType: `point`,
+  },
+  ts: 12.345,
+};
+
+const timespanData = {
+  annotationType: `timespan`,
+  endTime:        67.871,
+  notes:          [
+    {
+      text: `Speaker 2 was not present for this part of the text.`,
+    },
+  ],
+  startTime: 12.345,
+  tags:      {
+    intonationContour: `sharpRise`,
+  },
+};
+
+describe(`Annotation`, () => {
+
+  beforeAll(async function setup() {
+    ajv = await AJV();
+    validate = d => ajv.validate(`Annotation`, d);
+  });
+
+  it(`validates: timestamp`, () => {
+    const valid = validate(timestampData);
+    if (valid) expect(valid).toBe(true);
+    else fail(ajv.errorsText());
+  });
+
+  it(`validates: timespan`, () => {
+    const valid = validate(timespanData);
+    if (valid) expect(valid).toBe(true);
+    else fail(ajv.errorsText());
+  });
+
+});


### PR DESCRIPTION
## Related Issue
#81

## Description
This update adds an Annotation schema to the specification, and uses it in Text.annotation.

## Changelog
NEW: Annotation schema
NEW: Text.annotations

## Maintainer Checklist

- [ ] **Run upload script**: `npm run upload`
- [ ] **Write the release note** for the PR
- [ ] **Squash & merge PR into `master`**
    - Title: `LABEL: description (#000)`
    - Description
    - Changelog: `LABEL: description (closes #000)`
