### PR TITLE
always use a clean build of /docs folder when building the project

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,4 +56,8 @@
 
 - [ ] **Address any changes requested by the reviewer**. While working on your pull request, you can write `[ci skip]` in each of your commit messages to skip automated testing, until you are ready to test your code.
 
+- [ ] **Wait for your pull request to be merged.**
+
+- [ ] **Delete your issue branch.**
+
 - [ ] **Celebrate!!!** :fireworks: Your work is complete! Thank you for your valuable contribution to DLx!

--- a/build/docs.js
+++ b/build/docs.js
@@ -1,0 +1,66 @@
+// IMPORTS
+
+const generateDocs = require(`jschemer`);
+const path         = require(`path`);
+
+const {
+  mkdirp: createDir,
+  remove: removeDir,
+  writeFile,
+} = require(`fs-extra`);
+
+// VARIABLES
+
+/**
+ * The contents of the CNAME file
+ */
+const CNAME = `spec.digitallinguistics.io`;
+
+/**
+ * The path to the /docs folder
+ */
+const docsDir = path.join(__dirname, `../docs`);
+
+/**
+ * The options passed to jschemer
+ */
+const jschemerOptions = {
+  out:     path.join(__dirname, `../docs`),
+  readme:  path.join(__dirname, `../.github/README.md`),
+  schemas: path.join(__dirname, `../schemas/json`),
+};
+
+// METHODS
+
+/**
+ * Generates the CNAME file used for GitHub pages in the /docs folder
+ * @return {Promise}
+ */
+async function generateCNAME() {
+  const cnamePath = path.join(docsDir, `CNAME`);
+  await writeFile(cnamePath, CNAME, `utf8`);
+}
+
+// TOP-LEVEL SCRIPT
+
+/**
+ * Builds the project documentation in the /docs folder
+ * - deletes the /docs folder and recreates it
+ * - generates the jschemer documentation inside the /docs folder
+ * - adds the CNAME file (for GitHub pages) inside the /docs folder
+ * @return {Promise}
+ */
+async function buildDocs() {
+  await removeDir(docsDir);
+  await createDir(docsDir);
+  await generateDocs(jschemerOptions);
+  await generateCNAME();
+}
+
+// EXPORTS
+
+// Run this script if called directly from the command line
+if (require.main === module) buildDocs();
+
+// Export the buildDocs function if called from another script
+else module.exports = buildDocs;

--- a/package-lock.json
+++ b/package-lock.json
@@ -585,6 +585,17 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -630,8 +641,7 @@
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "handlebars": {
       "version": "4.1.1",
@@ -906,6 +916,15 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsonparse": {
       "version": "1.2.0",
@@ -1601,6 +1620,12 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "azure-storage": "^2.10.2",
     "chalk": "^2.4.2",
     "eslint": "^5.15.3",
+    "fs-extra": "^7.0.1",
     "jasmine": "^3.3.1",
     "jschemer": "^3.0.3",
     "semver-regex": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "npm run convert & npm run docs",
     "convert": "node build/convert.js",
-    "docs": "jschemer -o docs -s schemas/json -r ./.github/README.md",
+    "docs": "node build/docs.js",
     "prepare": "npm run build",
     "test": "jasmine JASMINE_CONFIG_PATH=test/jasmine.json",
     "upload": "node build/upload.js"


### PR DESCRIPTION
## Related Issue
#290

## Description
This PR updates the `docs` script used during the build process to make a clean build of the `/docs` folder each time the script is run.