### PR TITLE
Added License field to Access schema

### DIFF
--- a/docs/schemas/Access.html
+++ b/docs/schemas/Access.html
@@ -542,6 +542,94 @@
 
 </section>
 </li>
+                <li><section  class=jschemer-schema>
+
+
+    <details open>
+
+
+        <summary>
+          <h1 class='title keyword'>
+            License: <code>license</code>
+          </h1>
+        </summary>
+
+
+
+        <p class='type keyword'>
+          <b>Type:</b> <code>string</code>
+        </p>
+
+
+
+        <section class='description keyword'>
+          <h2>Description</h2>
+          <div><p>The license under which you want to release this resource, most likely a SPDX abbreviation. If you do not want to release this data to others, set this to <code>UNLICENSED.</code> Otherwise, use <a href="http://choosealicense.com">choosealicense.com</a> to decide which license is right for your usage.</p>
+</div>
+        </section>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        <section class='default keyword'>
+
+          <h2>Default Value</h2>
+
+          <p>The default value for this item is:</p>
+
+          <pre><code>&quot;UNLICENSED&quot;</code></pre>
+
+        </section>
+
+
+    </details>
+
+
+</section>
+</li>
             </ul>
 
           </section>
@@ -651,6 +739,7 @@
                 <pre><code>{
   &quot;AILLA&quot;: &quot;password&quot;,
   &quot;ELAR&quot;: &quot;Community Member&quot;,
+  &quot;license&quot;: &quot;UNLICENSED&quot;,
   &quot;notes&quot;: {
     &quot;eng&quot;: &quot;Speaker also requested that this text only be shared with family members.&quot;
   },

--- a/schemas/json/Access.json
+++ b/schemas/json/Access.json
@@ -36,12 +36,19 @@
         "Subscriber"
       ],
       "default": "Researcher"
+    },
+    "license": {
+      "title": "License",
+      "type": "string",
+      "description": "The license under which you want to release this resource, most likely a SPDX abbreviation. If you do not want to release this data to others, set this to `UNLICENSED.` Otherwise, use choosealicense.com to decide which license is right for your usage.",
+      "default": "UNLICENSED"
     }
   },
   "examples": [
     {
       "AILLA": "password",
       "ELAR": "Community Member",
+      "license": "UNLICENSED",
       "notes": {
         "eng": "Speaker also requested that this text only be shared with family members."
       },

--- a/schemas/yaml/Access.yml
+++ b/schemas/yaml/Access.yml
@@ -40,7 +40,7 @@ properties:
   license:
     title: 'License'
     type:  string
-    description: 'The license under which you want to release this resource, most likely a SPDX abbreviation. If you don't want to release this data to others, set this to `UNLICENSED.` Otherwise, use choosealicense.com to decide which license is right for your usage.'
+    description: 'The license under which you want to release this resource, most likely a SPDX abbreviation. If you do not want to release this data to others, set this to `UNLICENSED.` Otherwise, use choosealicense.com to decide which license is right for your usage.'
     default: 'UNLICENSED'
 
 examples:

--- a/schemas/yaml/Access.yml
+++ b/schemas/yaml/Access.yml
@@ -37,10 +37,17 @@ properties:
       - 'Subscriber'
     default: 'Researcher'
 
+  license:
+    title: 'License'
+    type:  string
+    description: 'The license under which you want to release this resource, most likely a SPDX abbreviation. If you don't want to release this data to others, set this to `UNLICENSED.` Otherwise, use choosealicense.com to decide which license is right for your usage.'
+    default: 'UNLICENSED'
+
 examples:
 
   - AILLA: 'password'
     ELAR:  'Community Member'
+    license: 'UNLICENSED'
     notes:
       eng: 'Speaker also requested that this text only be shared with family members.'
     speaker: 'family'

--- a/schemas/yaml/Access.yml
+++ b/schemas/yaml/Access.yml
@@ -1,5 +1,5 @@
 $schema: 'http://json-schema.org/draft-07/schema#'
-$id:     'http://schemas.digitallinguistics.io/Access-3.1.0.json'
+$id:     'http://schemas.digitallinguistics.io/Access-3.2.0.json'
 title:   'Access Rights'
 type:    object
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Issue
<!-- This project only accepts pull requests related to open issues. -->
https://github.com/digitallinguistics/spec/issues/309
<!-- Please link to the issue here, or open an issue if you have not already. -->

## Description
<!-- in 1-3 sentences, please provide a high-level overview of what changes were made. -->
Mechanically, this field is just a string. The onus is left on the end user to use it in a meaningful way. Right now the 'unlicensed' is the default value.
<!-- If appropriate, document your reasoning for why you made the changes the way you did. -->