### PR TITLE
DOCS: update maintainers doc with info about example data

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -12,7 +12,7 @@
 
 - **major:** breaking changes to schemas / properties or functional changes to their descriptions
 - **minor:** new properties added, optional properties removed, or other backwards-compatible changes
-- **patch:** typos, non-functional changes to descriptions, minor bugs and hotfixes
+- **patch:** typos, non-functional changes to descriptions, minor bugs and hotfixes, updates to example data
 
 ## Releases
 


### PR DESCRIPTION
Updates to example data only constitute a patch rather than a minor version bump.