### PR TITLE
Updated key regex to allow underscores and dashes

### DIFF
--- a/docs/schemas/Lexeme.html
+++ b/docs/schemas/Lexeme.html
@@ -200,7 +200,7 @@
 </nav>
 
     <main>
-      <section id=http://schemas.digitallinguistics.io/Lexeme-8.3.0.json class=jschemer-schema>
+      <section id=http://schemas.digitallinguistics.io/Lexeme-8.3.1.json class=jschemer-schema>
 
 
     <details open>
@@ -217,7 +217,7 @@
         </p>
 
         <p class='$id keyword'>
-          <b>Schema ID:</b> <code>http://schemas.digitallinguistics.io/Lexeme-8.3.0.json</code>
+          <b>Schema ID:</b> <code>http://schemas.digitallinguistics.io/Lexeme-8.3.1.json</code>
         </p>
 
         <p class='type keyword'>
@@ -523,7 +523,7 @@
 
 
           <p class='pattern keyword'>
-            <b>Regular expression to match:</b> <code>^[^ ]+$</code>
+            <b>Regular expression to match:</b> <code>^[^\s]+$</code>
           </p>
 
 
@@ -4811,7 +4811,7 @@
   &quot;dateCreated&quot;: &quot;2018-11-03T00:23:55.842Z&quot;,
   &quot;dateModified&quot;: &quot;2018-11-03T00:24:04.730Z&quot;,
   &quot;id&quot;: &quot;783cbaa8-befe-4049-bfe4-bb5688173780&quot;,
-  &quot;key&quot;: &quot;guxt&quot;,
+  &quot;key&quot;: &quot;guxt-(1)&quot;,
   &quot;language&quot;: {
     &quot;abbreviation&quot;: &quot;chiti&quot;,
     &quot;id&quot;: &quot;3d91a22d-005b-4ec5-8151-09e44629f58f&quot;

--- a/docs/schemas/Utterance.html
+++ b/docs/schemas/Utterance.html
@@ -200,7 +200,7 @@
 </nav>
 
     <main>
-      <section id=http://schemas.digitallinguistics.io/Utterance-5.1.0.json class=jschemer-schema>
+      <section id=http://schemas.digitallinguistics.io/Utterance-5.1.1.json class=jschemer-schema>
 
 
     <details open>
@@ -217,7 +217,7 @@
         </p>
 
         <p class='$id keyword'>
-          <b>Schema ID:</b> <code>http://schemas.digitallinguistics.io/Utterance-5.1.0.json</code>
+          <b>Schema ID:</b> <code>http://schemas.digitallinguistics.io/Utterance-5.1.1.json</code>
         </p>
 
         <p class='type keyword'>
@@ -411,7 +411,7 @@
 
         <section class='description keyword'>
           <h2>Description</h2>
-          <div><p>A key which uniquely identifies this Utterance within the Text. The key for an Utterance consists of the abbreviation of the Text, a period, and then the number of this Utterance within the Text (index starts at 1). For example, the third Utterance of a Text with the abbreviation <code>A</code> would be <code>A.3</code>. Keys should be unique within a corpus.</p>
+          <div><p>A key which uniquely identifies this Utterance within the Text. The key for an Utterance consists of the abbreviation of the Text, a period, dash, or underscore, and then the number of this Utterance within the Text (index starts at 1). For example, the third Utterance of a Text with the abbreviation <code>A</code> would be <code>A.3</code>. Keys should be unique within a corpus.</p>
 </div>
         </section>
 
@@ -450,7 +450,7 @@
 
 
           <p class='pattern keyword'>
-            <b>Regular expression to match:</b> <code>^[(a-z)|(A-Z)|(0-9)]+\.[0-9]{1,3}$</code>
+            <b>Regular expression to match:</b> <code>^[(a-z)|(A-Z)|(0-9)]+[-_\.][0-9]{1,3}$</code>
           </p>
 
 

--- a/docs/schemas/Word.html
+++ b/docs/schemas/Word.html
@@ -200,7 +200,7 @@
 </nav>
 
     <main>
-      <section id=http://schemas.digitallinguistics.io/Word-4.3.0.json class=jschemer-schema>
+      <section id=http://schemas.digitallinguistics.io/Word-4.3.1.json class=jschemer-schema>
 
 
     <details open>
@@ -217,7 +217,7 @@
         </p>
 
         <p class='$id keyword'>
-          <b>Schema ID:</b> <code>http://schemas.digitallinguistics.io/Word-4.3.0.json</code>
+          <b>Schema ID:</b> <code>http://schemas.digitallinguistics.io/Word-4.3.1.json</code>
         </p>
 
         <p class='type keyword'>
@@ -626,7 +626,7 @@
 
         <section class='description keyword'>
           <h2>Description</h2>
-          <div><p>A key that uniquely identifies this word token within the Text. The key for a Word consists of the abbreviation of the text, a period, the number of Utterance within the text, another period, and then the number of this word within the Utterance (indexing starts at 1). For example, for the fourth word of the third Utterance of a text with the abbreviation <code>A</code>, the key would be <code>A.3.4</code>. Keys should be unique within a corpus.</p>
+          <div><p>A key that uniquely identifies this word token within the Text. The key for a Word consists of the abbreviation of the text, a period, dash, or underscore, the number of Utterance within the text, another period, dash, or underscore, and then the number of this word within the Utterance (indexing starts at 1). For example, for the fourth word of the third Utterance of a text with the abbreviation <code>A</code>, the key would be <code>A.3.4</code>. Keys should be unique within a corpus.</p>
 </div>
         </section>
 
@@ -665,7 +665,7 @@
 
 
           <p class='pattern keyword'>
-            <b>Regular expression to match:</b> <code>^[(a-z)|(A-Z)|(0-9)]+\.[0-9]{1,3}\.[0-9]{1,2}$</code>
+            <b>Regular expression to match:</b> <code>^[(a-z)|(A-Z)|(0-9)]+[-_\.][0-9]{1,3}[-_\.][0-9]{1,2}$</code>
           </p>
 
 
@@ -2288,7 +2288,7 @@
   &quot;type&quot;: &quot;Word&quot;,
   &quot;endtime&quot;: 1.01,
   &quot;gloss&quot;: &quot;man&quot;,
-  &quot;key&quot;: &quot;A1.1.2&quot;,
+  &quot;key&quot;: &quot;A1_1_2&quot;,
   &quot;analysis&quot;: {
     &quot;transcription&quot;: &quot;man&quot;
   },

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "main": "schemas/json",
   "scripts": {
-    "build":   "npm run convert & npm run docs",
+    "build": "npm run convert & npm run docs",
     "convert": "node build/convert.js",
-    "docs":    "node build/docs.js",
+    "docs": "node build/docs.js",
     "prepare": "npm run build",
-    "test":    "jasmine JASMINE_CONFIG_PATH=test/jasmine.json",
-    "upload":  "node build/upload.js"
+    "test": "jasmine JASMINE_CONFIG_PATH=test/jasmine.json",
+    "upload": "node build/upload.js"
   },
   "dependencies": {},
   "devDependencies": {

--- a/schemas/json/Lexeme.json
+++ b/schemas/json/Lexeme.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://schemas.digitallinguistics.io/Lexeme-8.3.0.json",
+  "$id": "http://schemas.digitallinguistics.io/Lexeme-8.3.1.json",
   "title": "Lexeme",
   "type": "object",
   "description": "A *lexeme* is an abstract entity that represents all the various forms of a word. In DLx, a lexeme refers broadly to any bundle of related senses and forms, whether the item is an individual word, morpheme, idiom, etc. — anything that constitues a semantic unit. Examples of lexemes in English might include *be*, *run up*, and *‑ing*. A lexeme will typically have multiple *senses* or meanings, and those are listed in the `senses` property. It is up to the linguist to decide when two meanings are related, and therefore belong to the same lexeme, or when they belong to different lexemes. A lexeme often also has multiple base forms, such as suppletive forms, irregular forms, or morphologically-conditioned forms. For example, the lexeme *be* has the base forms *be*, *am*, *is*, etc. These are listed in the `forms` field. The `forms` field should **not** be used to list all the regularly-inflected forms of a word. Individual base forms may have phonologically-conditioned allomorphs, and these are listed in the `allomorphs` field of the form. The lexeme and its forms and senses may also have variations, such as dialectal and idiolectal variants, rapid speech variants, register-based variants, variations in meaning, or even spelling variants. These are listed in the `variants` fields. By convention, one of the forms of a lexeme is typically chosen as a representative headword or *lemma*, and this is indicated by the `lemma` field. For example, the form *man* is typically used as the lemma/headword for the lexeme that includes the forms *man* and *men*. Note that the DLx Lexeme does **not** represent a lexical entry in a dictionary. Dictionaries typically list each base form of a lexeme as a separate lexical entry. The DLx Lexeme lists puts each of these lexical entries together in the `forms` field instead.",
@@ -31,7 +31,7 @@
     "key": {
       "title": "Lexeme Key",
       "type": "string",
-      "pattern": "^[^ ]+$",
+      "pattern": "^[^\\s]+$",
       "description": "A human-readable key that uniquely identifies this lexeme or variant within the language. Best practice is for the key to consist of a representation of the lemma form of the word without diacritics, and, if the word is a homonym, the homonym number. However, any value is acceptable as long as it is unique for the language. (Keys do not need to be unique across languages.)"
     },
     "alternativeAnalyses": {
@@ -362,7 +362,7 @@
       "dateCreated": "2018-11-03T00:23:55.842Z",
       "dateModified": "2018-11-03T00:24:04.730Z",
       "id": "783cbaa8-befe-4049-bfe4-bb5688173780",
-      "key": "guxt",
+      "key": "guxt-(1)",
       "language": {
         "abbreviation": "chiti",
         "id": "3d91a22d-005b-4ec5-8151-09e44629f58f"

--- a/schemas/json/Utterance.json
+++ b/schemas/json/Utterance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://schemas.digitallinguistics.io/Utterance-5.1.0.json",
+  "$id": "http://schemas.digitallinguistics.io/Utterance-5.1.1.json",
   "title": "Utterance",
   "type": "object",
   "description": "The term *utterance* is intentionally ambiguous, and refers to any unit of a text above the word level. The DLx framework imposes no requirements regarding this size of this unit or how segmentation of the text into units should be accomplished. The user may choose to segment a text based on prosodic units, turns, sentences, or any other appropriate subdivision.",
@@ -28,8 +28,8 @@
     "key": {
       "title": "Key",
       "type": "string",
-      "pattern": "^[(a-z)|(A-Z)|(0-9)]+\\.[0-9]{1,3}$",
-      "description": "A key which uniquely identifies this Utterance within the Text. The key for an Utterance consists of the abbreviation of the Text, a period, and then the number of this Utterance within the Text (index starts at 1). For example, the third Utterance of a Text with the abbreviation `A` would be `A.3`. Keys should be unique within a corpus."
+      "pattern": "^[(a-z)|(A-Z)|(0-9)]+[-_\\.][0-9]{1,3}$",
+      "description": "A key which uniquely identifies this Utterance within the Text. The key for an Utterance consists of the abbreviation of the Text, a period, dash, or underscore, and then the number of this Utterance within the Text (index starts at 1). For example, the third Utterance of a Text with the abbreviation `A` would be `A.3`. Keys should be unique within a corpus."
     },
     "endTime": {
       "title": "End Time",

--- a/schemas/json/Word.json
+++ b/schemas/json/Word.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://schemas.digitallinguistics.io/Word-4.3.0.json",
+  "$id": "http://schemas.digitallinguistics.io/Word-4.3.1.json",
   "title": "Word",
   "type": "object",
   "description": "A Word object represents a specific token in a text, rather than an abstract lexeme (see the Lexeme object for that).",
@@ -35,8 +35,8 @@
     "key": {
       "title": "Key",
       "type": "string",
-      "pattern": "^[(a-z)|(A-Z)|(0-9)]+\\.[0-9]{1,3}\\.[0-9]{1,2}$",
-      "description": "A key that uniquely identifies this word token within the Text. The key for a Word consists of the abbreviation of the text, a period, the number of Utterance within the text, another period, and then the number of this word within the Utterance (indexing starts at 1). For example, for the fourth word of the third Utterance of a text with the abbreviation `A`, the key would be `A.3.4`. Keys should be unique within a corpus."
+      "pattern": "^[(a-z)|(A-Z)|(0-9)]+[-_\\.][0-9]{1,3}[-_\\.][0-9]{1,2}$",
+      "description": "A key that uniquely identifies this word token within the Text. The key for a Word consists of the abbreviation of the text, a period, dash, or underscore, the number of Utterance within the text, another period, dash, or underscore, and then the number of this word within the Utterance (indexing starts at 1). For example, for the fourth word of the third Utterance of a text with the abbreviation `A`, the key would be `A.3.4`. Keys should be unique within a corpus."
     },
     "literal": {
       "title": "Literal Translation",
@@ -155,7 +155,7 @@
       "type": "Word",
       "endtime": 1.01,
       "gloss": "man",
-      "key": "A1.1.2",
+      "key": "A1_1_2",
       "analysis": {
         "transcription": "man"
       },

--- a/schemas/yaml/Lexeme.yml
+++ b/schemas/yaml/Lexeme.yml
@@ -1,5 +1,5 @@
 $schema: 'http://json-schema.org/draft-07/schema#'
-$id:     'http://schemas.digitallinguistics.io/Lexeme-8.3.0.json'
+$id:     'http://schemas.digitallinguistics.io/Lexeme-8.3.1.json'
 title:   Lexeme
 type:    object
 
@@ -34,7 +34,7 @@ properties:
   key:
     title:   Lexeme Key
     type:    string
-    pattern: '^[^ ]+$'
+    pattern: '^[^\s]+$'
     description: A human-readable key that uniquely identifies this lexeme or variant within the language. Best practice is for the key to consist of a representation of the lemma form of the word without diacritics, and, if the word is a homonym, the homonym number. However, any value is acceptable as long as it is unique for the language. (Keys do not need to be unique across languages.)
 
   alternativeAnalyses:
@@ -305,7 +305,7 @@ examples:
     dateCreated:    '2018-11-03T00:23:55.842Z'
     dateModified:   '2018-11-03T00:24:04.730Z'
     id:             783cbaa8-befe-4049-bfe4-bb5688173780
-    key:            guxt
+    key:            guxt-(1)
     language:
       abbreviation: chiti
       id:           3d91a22d-005b-4ec5-8151-09e44629f58f

--- a/schemas/yaml/Utterance.yml
+++ b/schemas/yaml/Utterance.yml
@@ -1,5 +1,5 @@
 $schema: 'http://json-schema.org/draft-07/schema#'
-$id:     'http://schemas.digitallinguistics.io/Utterance-5.1.0.json'
+$id:     'http://schemas.digitallinguistics.io/Utterance-5.1.1.json'
 title:   Utterance
 type:    object
 
@@ -29,8 +29,8 @@ properties:
   key:
     title:   Key
     type:    string
-    pattern: '^[(a-z)|(A-Z)|(0-9)]+\.[0-9]{1,3}$'
-    description: 'A key which uniquely identifies this Utterance within the Text. The key for an Utterance consists of the abbreviation of the Text, a period, and then the number of this Utterance within the Text (index starts at 1). For example, the third Utterance of a Text with the abbreviation `A` would be `A.3`. Keys should be unique within a corpus.'
+    pattern: '^[(a-z)|(A-Z)|(0-9)]+[-_\.][0-9]{1,3}$'
+    description: 'A key which uniquely identifies this Utterance within the Text. The key for an Utterance consists of the abbreviation of the Text, a period, dash, or underscore, and then the number of this Utterance within the Text (index starts at 1). For example, the third Utterance of a Text with the abbreviation `A` would be `A.3`. Keys should be unique within a corpus.'
 
   endTime:
     title:   'End Time'
@@ -91,7 +91,7 @@ properties:
     description: 'The literal translations for this Utterance, optionally in multiple languages.'
 
   phonetic:
-    title:  Phonetic 
+    title:  Phonetic
     type:   string
     description: 'The phonetic transcription for this Utterance in IPA. Only valid IPA characters are allowed. The transcription should not include phonetic brackets.'
 

--- a/schemas/yaml/Word.yml
+++ b/schemas/yaml/Word.yml
@@ -1,5 +1,5 @@
 $schema: 'http://json-schema.org/draft-07/schema#'
-$id:     'http://schemas.digitallinguistics.io/Word-4.3.0.json'
+$id:     'http://schemas.digitallinguistics.io/Word-4.3.1.json'
 title:   Word
 type:    object
 
@@ -38,8 +38,8 @@ properties:
   key:
     title:   Key
     type:    string
-    pattern: '^[(a-z)|(A-Z)|(0-9)]+\.[0-9]{1,3}\.[0-9]{1,2}$'
-    description: 'A key that uniquely identifies this word token within the Text. The key for a Word consists of the abbreviation of the text, a period, the number of Utterance within the text, another period, and then the number of this word within the Utterance (indexing starts at 1). For example, for the fourth word of the third Utterance of a text with the abbreviation `A`, the key would be `A.3.4`. Keys should be unique within a corpus.'
+    pattern: '^[(a-z)|(A-Z)|(0-9)]+[-_\.][0-9]{1,3}[-_\.][0-9]{1,2}$'
+    description: 'A key that uniquely identifies this word token within the Text. The key for a Word consists of the abbreviation of the text, a period, dash, or underscore, the number of Utterance within the text, another period, dash, or underscore, and then the number of this word within the Utterance (indexing starts at 1). For example, for the fourth word of the third Utterance of a text with the abbreviation `A`, the key would be `A.3.4`. Keys should be unique within a corpus.'
 
   literal:
     title: 'Literal Translation'
@@ -159,7 +159,7 @@ examples:
   - type:    Word
     endtime: 1.010
     gloss:   man
-    key:     A1.1.2
+    key:     A1_1_2
     analysis:
       transcription: man
     literal:         eng: man


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Issue
<!-- This project only accepts pull requests related to open issues. -->
<!-- Please link to the issue here, or open an issue if you have not already. -->
#350 
## Description
<!-- in 1-3 sentences, please provide a high-level overview of what changes were made. -->
<!-- If appropriate, document your reasoning for why you made the changes the way you did. -->
I updates all the key fields in the schemas to allow underscores and dashes. For Word and Utterance, dashes/underscores are used as an alternate separator character, periods will continue to work as well. The only other key fields are in Lexeme and Database reference. Both of those fields already accepted dashes and underscores, but I updated the Lexeme key field so that it wouldn't accept any whitespace characters.
## Changelog
<!-- What specific changes were made? List each change as a bullet point with a label. -->
<!-- See the issues tracker for a list of labels to use. -->
<!-- Some examples: -->

<!-- DOCS: add documentation about new app.sync() method -->
<!-- NEW: add app.sync() method to App object -->
<!-- CHANGE: update app.init() to call app.sync() -->

- Updated Regex pattern for the key fields in Word, Utterance, and Lexeme