### PR TITLE
Language names

### DIFF
--- a/schemas/json/Language.json
+++ b/schemas/json/Language.json
@@ -33,47 +33,29 @@
       "$ref": "http://schemas.digitallinguistics.io/Access.json",
       "description": "An object describing who may have access to materials on this language."
     },
-    "additionalNames": {
-      "title": "Additional Names",
+    "autonyms": {
+      "title": "Autonyms",
       "type": "array",
-      "uniqueItems": true,
-      "description": "An Array of additional names for this Language. Only use this property if the `name` property is not sufficient to describe the various names for this language. This field is especially useful when the Language has multiple spellings in historical documentation. Each additional name can be a plain string, or an object with two properties: `name` and `note`. The object format is preferred, since the `note` field provides a way to give a description of this additional name and where or by whom it was used.",
+      "description": "A list of objects describing autonyms for this language (names for this language _in_ the language itself). For the canonical scientific name, use the `name` field instead. For other ways of referring to this language by outsiders, use the `exonyms` field.",
       "items": {
-        "title": "Additional Language Name",
-        "oneOf": [
-          {
-            "type": "string",
-            "minLength": 1
+        "title": "Autonym",
+        "type": "object",
+        "required": [
+          "transcription"
+        ],
+        "properties": {
+          "transcription": {
+            "title": "Autonym Transcription",
+            "$ref": "http://schemas.digitallinguistics.io/Transcription.json",
+            "description": "A transcription of this autonym, optionally in multiple orthographies."
           },
-          {
-            "type": "object",
-            "required": [
-              "name",
-              "note"
-            ],
-            "properties": {
-              "name": {
-                "title": "Additional Language Name",
-                "type": "string",
-                "minLength": 1,
-                "description": "The additional language name"
-              },
-              "note": {
-                "title": "Additional Language Note",
-                "type": "object",
-                "$ref": "http://schemas.digitallinguistics.io/Note.json",
-                "description": "A note about this additional language, explaining where it is used and who uses it. You should use the `language` property of the Note to describe what language this additional name is in."
-              }
-            }
+          "note": {
+            "title": "Note",
+            "$ref": "http://schemas.digitallinguistics.io/Note.json",
+            "description": "A note about this autonym, such as who uses this name and where, or perhaps its etymology."
           }
-        ]
+        }
       }
-    },
-    "autonym": {
-      "title": "Autonym",
-      "type": "object",
-      "$ref": "http://schemas.digitallinguistics.io/Transcription.json",
-      "description": "The autonym for this language, optionally in multiple orthographies. Note that this is a transcription of the autonym, and so should not be capitalized."
     },
     "bibliography": {
       "title": "Bibliography",
@@ -257,6 +239,30 @@
       "$ref": "http://schemas.digitallinguistics.io/MultiLangString.json",
       "description": "A high-level overview of the Language and the sociohistorical and documentary context for the accompanying data"
     },
+    "exonyms": {
+      "title": "Exonyms",
+      "type": "array",
+      "description": "A list of exonyms for this language (names of the language in _other_ languages). For the canonical scientific name of the language (usually in English), use the `name` field. This field is for any additional exonyms beyond the canonical scientific name. For autonyms (names of the language _in_ the language), use the `autonyms` field.",
+      "items": {
+        "title": "Exonym",
+        "type": "object",
+        "required": [
+          "transcription"
+        ],
+        "properties": {
+          "transcription": {
+            "title": "Exonym Transcription",
+            "$ref": "http://schemas.digitallinguistics.io/MultiLangString.json",
+            "description": "A transcription of this exonym, optionally in multiple languages."
+          },
+          "note": {
+            "title": "Note",
+            "$ref": "http://schemas.digitallinguistics.io/Note.json",
+            "description": "A note about this exonym, such as who uses this name and where, or perhaps its etymology."
+          }
+        }
+      }
+    },
     "glottolog": {
       "title": "Glottolog Code",
       "type": "string",
@@ -290,7 +296,8 @@
     "name": {
       "title": "Language Name",
       "$ref": "http://schemas.digitallinguistics.io/MultiLangString.json",
-      "description": "The name of this Language, optionally in multiple languages. There must be a name provided in at least one language. Use the `additionalNames` field to list names for this language that need additional explanation or notes, or if there are multiple names for this variety in a language."
+      "minProperties": 1,
+      "description": "The canonical scientific name of this language, usually in English, and also optionally in multiple languages. There must be a name provided in at least one language. Use the `exonyms` field to list other ways this language is referred to, and the `autonyms` field to list names for the language _in_ the language itself (a.k.a. endonyms)."
     },
     "notes": {
       "title": "Notes",
@@ -349,24 +356,19 @@
           "eng": "Materials on this language should not be made available to non-tribal members without permission."
         }
       },
-      "additionalNames": [
+      "autonyms": [
         {
-          "name": "Shetimashas",
+          "transcription": {
+            "APA": "sitimaša",
+            "IPA": "sitimaʃa",
+            "Mod": "sitimaxa",
+            "Swad": "sitimaša"
+          },
           "note": {
-            "source": {
-              "abbreviation": "DWH"
-            },
-            "text": "This is the name commonly used for the language by French colonials."
+            "text": "This is the traditional name used for the Chitimacha language by the Chitimacha people themselves. It most likely derives from _siit‑_ 'body of water' + _‑ma_ pluractional + _‑x_ topic marker, meaning 'people of the waters'. This is most likely a reference to the fact that the Chitimacha people live deep in the bayou waterways of Louisiana."
           }
-        },
-        "Chetimachas"
+        }
       ],
-      "autonym": {
-        "APA": "sitimaša",
-        "IPA": "sitimaʃa",
-        "Mod": "sitimaxa",
-        "Swad": "sitimaša"
-      },
       "bibliography": [
         {
           "citationKey": "Swadesh1946"
@@ -395,6 +397,17 @@
       "dateCreated": "2018-10-13T18:16:57.497Z",
       "dateModified": "2018-10-13T18:17:06.515Z",
       "defaultOrthography": "modern",
+      "exonyms": [
+        {
+          "transcription": "Shetimashas",
+          "note": {
+            "text": "This is the name commonly used for the language by French colonials, borrowed from the Chitimacha name for the language, _Sitimaxa_."
+          }
+        },
+        {
+          "transcription": "Chetimachas"
+        }
+      ],
       "glottolog": "chit1248",
       "id": "4d633ee3-25ba-4add-83cf-b588ba51f758",
       "iso": "ctm",
@@ -676,22 +689,15 @@
           "eng": "Unless otherwise noted, materials for this language may be made publicly accessible, and the speakers in the content identified."
         }
       },
-      "additionalNames": [
+      "autonyms": [
         {
-          "name": "Kikisii",
-          "note": {
-            "source": {
-              "abbreviation": "DWH"
-            },
-            "text": "This is a Swahili version of the name of this language. It is an alternate for simply `Kisii`."
+          "transcription": {
+            "IPA": "ékeɣusií",
+            "Gus": "ékegusií",
+            "Swa": "ekegusii"
           }
         }
       ],
-      "autonym": {
-        "IPA": "ékeɣusií",
-        "Gus": "ékegusií",
-        "Swa": "ekegusii"
-      },
       "classification": [
         "Niger-Congo",
         "Atlantic-Congo",
@@ -727,6 +733,24 @@
       ],
       "dateCreated": "2018-10-13T18:17:24.477Z",
       "dateModified": "2018-10-13T18:17:34.512Z",
+      "exonyms": [
+        {
+          "transcription": {
+            "swa": "Kisii"
+          },
+          "note": {
+            "text": "This is the most typical way that Swahili speakers refer to the language."
+          }
+        },
+        {
+          "transcription": {
+            "swa": "Kikisii"
+          },
+          "note": {
+            "text": "This is a Swahili version of the name of this language. It is an alternate for simply `Kisii`."
+          }
+        }
+      ],
       "glottolog": "gusi1247",
       "id": "708d1bd4-84f6-42e5-8b09-5c64493441b3",
       "iso": "guz",

--- a/schemas/yaml/Language.yml
+++ b/schemas/yaml/Language.yml
@@ -203,26 +203,45 @@ properties:
               description: 'The UNESCO Language Degree of Endangerment for this Demographic data. This status should be the string representation of the Degree of endangerment level.'
 
   description:
-    title:       'Description'
+    title:       Description
     $ref:        'http://schemas.digitallinguistics.io/MultiLangString.json'
-    description: 'A high-level overview of the Language and the sociohistorical and documentary context for the accompanying data'
+    description: A high-level overview of the Language and the sociohistorical and documentary context for the accompanying data
+
+  exonyms:
+    title: Exonyms
+    type:  array
+    description: A list of exonyms for this language (names of the language in _other_ languages). For the canonical scientific name of the language (usually in English), use the `name` field. This field is for any additional exonyms beyond the canonical scientific name. For autonyms (names of the language _in_ the language), use the `autonyms` field.
+    items:
+      title: Exonym
+      type:  object
+      required:
+        - transcription
+      properties:
+        transcription:
+          title:       Exonym Transcription
+          $ref:        'http://schemas.digitallinguistics.io/MultiLangString.json'
+          description: A transcription of this exonym, optionally in multiple languages.
+        note:
+          title:       Note
+          $ref:        'http://schemas.digitallinguistics.io/Note.json'
+          description: A note about this exonym, such as who uses this name and where, or perhaps its etymology.
 
   glottolog:
-    title:   'Glottolog Code'
-    type:    string
-    pattern: '^[a-z]{4}[0-9]{4}$'
-    description: 'The Glottolog code for this language variety, as a String in the format abcd1234'
+    title:       Glottolog Code
+    type:        string
+    pattern:     '^[a-z]{4}[0-9]{4}$'
+    description: The Glottolog code for this language variety, as a String in the format abcd1234
 
   iso:
-    title:   'ISO 639-3 Code'
-    type:    string
-    pattern: '^[a-z]{3}$'
-    description: 'The ISO 639-3 code for this language variety, as a 3-letter String'
+    title:       ISO 639-3 Code
+    type:        string
+    pattern:     '^[a-z]{3}$'
+    description: The ISO 639-3 code for this language variety, as a 3-letter String
 
   link:
-    title:  Link
-    type:   string
-    format: uri
+    title:       Link
+    type:        string
+    format:      uri
     description: 'A URL where a presentational format for this resource may be viewed'
 
   locations:

--- a/schemas/yaml/Language.yml
+++ b/schemas/yaml/Language.yml
@@ -36,11 +36,24 @@ properties:
     $ref:  'http://schemas.digitallinguistics.io/Access.json'
     description: An object describing who may have access to materials on this language.
 
-  autonym:
-    title: Autonym
-    type:  object
-    $ref:  'http://schemas.digitallinguistics.io/Transcription.json'
-    description: The autonym for this language, optionally in multiple orthographies. Note that this is a transcription of the autonym, and so should not be capitalized.
+  autonyms:
+    title: Autonyms
+    type:  array
+    description: A list of objects describing autonyms for this language (names for this language _in_ the language itself). For the canonical scientific name, use the `name` field instead. For other ways of referring to this language by outsiders, use the `exonyms` field.
+    items:
+      title: Autonym
+      type:  object
+      required:
+        - transcription
+      properties:
+        transcription:
+          title: Autonym Transcription
+          $ref:  'http://schemas.digitallinguistics.io/Transcription.json'
+          description: A transcription of this autonym, optionally in multiple orthographies.
+        note:
+          title: Note
+          $ref:  'http://schemas.digitallinguistics.io/Note.json'
+          description: A note about this autonym, such as who uses this name and where, or perhaps its etymology.
 
   bibliography:
     title:       Bibliography

--- a/schemas/yaml/Language.yml
+++ b/schemas/yaml/Language.yml
@@ -312,18 +312,14 @@ examples:
       AILLA: password
       note:
         eng: Materials on this language should not be made available to non-tribal members without permission.
-    additionalNames:
-      - name: Shetimashas
+    autonyms:
+      - transcription:
+          APA:  sitimaša
+          IPA:  sitimaʃa
+          Mod:  sitimaxa
+          Swad: sitimaša
         note:
-          source:
-            abbreviation: DWH
-          text:   This is the name commonly used for the language by French colonials.
-      - Chetimachas
-    autonym:
-      APA:  sitimaša
-      IPA:  sitimaʃa
-      Mod:  sitimaxa
-      Swad: sitimaša
+          text: This is the traditional name used for the Chitimacha language by the Chitimacha people themselves. It most likely derives from _siit‑_ 'body of water' + _‑ma_ pluractional + _‑x_ topic marker, meaning 'people of the waters'. This is most likely a reference to the fact that the Chitimacha people live deep in the bayou waterways of Louisiana.
     bibliography:
       - citationKey: Swadesh1946
     contributors:
@@ -339,6 +335,11 @@ examples:
     dateCreated:        '2018-10-13T18:16:57.497Z'
     dateModified:       '2018-10-13T18:17:06.515Z'
     defaultOrthography: modern
+    exonyms:
+      - transcription: Shetimashas
+        note:
+          text: This is the name commonly used for the language by French colonials, borrowed from the Chitimacha name for the language, _Sitimaxa_.
+      - transcription: Chetimachas
     glottolog:          chit1248
     id:                 4d633ee3-25ba-4add-83cf-b588ba51f758
     iso:                ctm
@@ -497,16 +498,11 @@ examples:
     access:
       note:
         eng: Unless otherwise noted, materials for this language may be made publicly accessible, and the speakers in the content identified.
-    additionalNames:
-      - name: Kikisii
-        note:
-          source:
-            abbreviation: DWH
-          text:   This is a Swahili version of the name of this language. It is an alternate for simply `Kisii`.
-    autonym:
-      IPA: ékeɣusií
-      Gus: ékegusií
-      Swa: ekegusii
+    autonyms:
+      - transcription:
+          IPA: ékeɣusií
+          Gus: ékegusií
+          Swa: ekegusii
     classification:
       - Niger-Congo
       - Atlantic-Congo
@@ -531,6 +527,15 @@ examples:
           - researcher
     dateCreated:  '2018-10-13T18:17:24.477Z'
     dateModified: '2018-10-13T18:17:34.512Z'
+    exonyms:
+      - transcription:
+          swa: Kisii
+        note:
+          text: This is the most typical way that Swahili speakers refer to the language.
+      - transcription:
+          swa: Kikisii
+        note:
+          text: This is a Swahili version of the name of this language. It is an alternate for simply `Kisii`.
     glottolog:    gusi1247
     id:           708d1bd4-84f6-42e5-8b09-5c64493441b3
     iso:          guz

--- a/schemas/yaml/Language.yml
+++ b/schemas/yaml/Language.yml
@@ -36,34 +36,6 @@ properties:
     $ref:  'http://schemas.digitallinguistics.io/Access.json'
     description: An object describing who may have access to materials on this language.
 
-  additionalNames:
-    title:       Additional Names
-    type:        array
-    uniqueItems: true
-    description: 'An Array of additional names for this Language. Only use this property if the `name` property is not sufficient to describe the various names for this language. This field is especially useful when the Language has multiple spellings in historical documentation. Each additional name can be a plain string, or an object with two properties: `name` and `note`. The object format is preferred, since the `note` field provides a way to give a description of this additional name and where or by whom it was used.'
-    items:
-      title: Additional Language Name
-      oneOf:
-
-        - type:      string
-          minLength: 1
-
-        - type: object
-          required:
-            - name
-            - note
-          properties:
-            name:
-              title:     'Additional Language Name'
-              type:      string
-              minLength: 1
-              description: 'The additional language name'
-            note:
-              title: 'Additional Language Note'
-              type:  object
-              $ref:  'http://schemas.digitallinguistics.io/Note.json'
-              description: 'A note about this additional language, explaining where it is used and who uses it. You should use the `language` property of the Note to describe what language this additional name is in.'
-
   autonym:
     title: Autonym
     type:  object

--- a/schemas/yaml/Language.yml
+++ b/schemas/yaml/Language.yml
@@ -227,7 +227,7 @@ properties:
     title:         Language Name
     $ref:          'http://schemas.digitallinguistics.io/MultiLangString.json'
     minProperties: 1
-    description: The name of this Language, optionally in multiple languages. There must be a name provided in at least one language. Use the `additionalNames` field to list names for this language that need additional explanation or notes, or if there are multiple names for this variety in a language.
+    description: The canonical scientific name of this language, usually in English, and also optionally in multiple languages. There must be a name provided in at least one language. Use the `exonyms` field to list other ways this language is referred to, and the `autonyms` field to list names for the language _in_ the language itself (a.k.a. endonyms).
 
   notes:
     title:       Notes


### PR DESCRIPTION
This PR restructures the name-related fields on the `Language` schema, following #366.

* `Language.name`
* `Language.autonyms`
* `Language.exonyms`
* remove `Language.additionalNames`

closes #366